### PR TITLE
Books.mediawiki: Remove target="blank" from titles + small fixes

### DIFF
--- a/Books.mediawiki
+++ b/Books.mediawiki
@@ -4,12 +4,12 @@
 : SDL Game Development guides you through creating your first 2D game using SDL 2.0 and C++. It takes a clear and practical approach to SDL game development, ensuring that the focus remains on creating awesome games.
 : ''"Written as a practical and engaging tutorial, SDL Game Development guides you through the development of your own framework and the creation of two exciting, fully-featured games."'' ~-(Packt Publishing)-~
 
-* [http://www.amazon.com/Learn-Making-Games-Charles-Programming/dp/1584504552/ref=sr_1_2?ie=UTF8&s=books&qid=1255150140&sr=8-2 Learn C++ by Making Games|target="blank"] by Erik Yuzwa & Francois Dominic Laramee
-: An introduction to C++, using it to develop games with SDL
+* [http://www.amazon.com/Learn-Making-Games-Charles-Programming/dp/1584504552/ref=sr_1_2?ie=UTF8&s=books&qid=1255150140&sr=8-2 Learn C++ by Making Games] by Erik Yuzwa & Francois Dominic Laramee
+: An introduction to C++, using it to develop games with SDL 1.2
 : ''"The book concludes with an exploration of how to use the Simple Direct<code></code>Media Layer to display graphics and handle basic input, sound, linked lists, templates, along with a variety of more advanced topics, including using SDL to create a simple demo."'' ~-(Amazon.com)-~
 
-* [http://www.amazon.com/Game-Programming-Start-Finish-Development/dp/1584504323/ref=sr_1_1?ie=UTF8&s=books&qid=1255150140&sr=8-1 Game Programming in C++ Start to Finish|target="blank"] by Erik Yuzwa
-: An introduction to game programming using SDL and OpenGL on Windows.
+* [http://www.amazon.com/Game-Programming-Start-Finish-Development/dp/1584504323/ref=sr_1_1?ie=UTF8&s=books&qid=1255150140&sr=8-1 Game Programming in C++ Start to Finish] by Erik Yuzwa
+: An introduction to game programming using SDL 1.2 and OpenGL on Windows.
 : ''"As you work through the book, you’ll build the SuperAsteriodArena game, beginning with engine creation and 3D programming with SDL and OpenGL. From there you’ll move on to animation effects, audio, collision detection, networking, and finalizing the game. A variety of tools are used throughout, including Visual Studio and OpenGL, SDL, Autodesk 3ds Max, and the Audacity sound tool. "'' ~-(Amazon.com)-~
 
 * [http://www.amazon.com/Teach-Yourself-Games-Programming-Computers/dp/0071544755 Teach Yourself Games Programming] by Alan Thorn
@@ -25,5 +25,5 @@
 : ''"SDL, a cross-platform graphics library, is used for the demos and the coverage of that is almost worth the price of admission. (though I recommend Focus on SDL in addition)"'' ~-(Amazon.com)-~
 
 * [http://www.nostarch.com/plg.htm Programming Linux Games] ([https://web.archive.org/web/20150626175448/http://www.nostarch.com/plg.htm Archive]) by Loki Software, Inc. with John R. Hall
-: Building Multimedia Applications with SDL, OpenAL^(tm)^, and Other APIs
+: Building Multimedia Applications with SDL, OpenAL™, and Other APIs
 : ''"This is the sort of book that could kickstart a new movement in Linux game development."'' ~-(Slashdot)-~


### PR DESCRIPTION
As per [Erik Yuzwa's request](https://github.com/libsdl-org/sdlwiki/issues/13#issue-847683808), I removed target="blank" from the titles of his books and added the clarification that they are on SDL 1.2 material.