### PR TITLE
Add some documentation for SDL_HINT_MOUSE_RELATIVE_SCALING

### DIFF
--- a/SDL_HINT_MOUSE_RELATIVE_SCALING.mediawiki
+++ b/SDL_HINT_MOUSE_RELATIVE_SCALING.mediawiki
@@ -1,0 +1,31 @@
+
+<!-- #*^*^*^*^*See https://wiki.libsdl.org/SGEnumerations for details on editing this page*^*^*^*^* -->
+
+
+= SDL_HINT_MOUSE_RELATIVE_SCALING =
+A hint that specifies whether relative motion is affected by renderer scaling.
+
+
+
+
+== Values ==
+{|
+|0
+|Relative motion is unaffected by DPI or renderer's logical size
+|-
+|1
+|Relative motion is scaled according to DPI scaling and logical size
+|}
+
+
+== Default ==
+By default relative mouse deltas are affected by DPI and renderer scaling
+
+
+
+== Version ==
+This hint is available since SDL 2.0.14.
+
+----
+[[CategoryDefine]], [[CategoryHints]]
+<!-- #See the Style Guide for instructions on editing the footer. -->

--- a/SDL_RenderSetLogicalSize.mediawiki
+++ b/SDL_RenderSetLogicalSize.mediawiki
@@ -42,7 +42,8 @@ ratio the output rendering will be centered within the output display.
 
 If the output display is a window, mouse and touch events in the window
 will be filtered and scaled so they seem to arrive within the logical
-resolution.
+resolution. The [[SDL_HINT_MOUSE_RELATIVE_SCALING]] hint controls whether
+relative motion events are also scaled.
 
 If this function results in scaling or subpixel drawing by the rendering
 backend, it will be handled using the appropriate quality hints.


### PR DESCRIPTION
This change adds two things:
- A page for the ``SDL_HINT_MOUSE_RELATIVE_SCALING`` hint.
- A link to said page from the ``SDL_RenderSetLogicalSize()`` page.

I did these both manually, as ``wikiheaders.pl`` doesn't handle #defines and enums yet, and I couldn't quite find a way of creating a new page from the ``ghwikipp`` interface.