### PR TITLE
SDL_LockMutex: Added code example.

### DIFF
--- a/SDL_LockMutex.mediawiki
+++ b/SDL_LockMutex.mediawiki
@@ -35,7 +35,29 @@ This function is available since SDL 2.0.0.
 
 == Code Examples ==
 
-<<Include(SDL_CreateMutex, , , from="## Begin Mutex Example", to="## End Mutex Example")>>
+<!-- # Begin Mutex Example -->
+<syntaxhighlight lang='c'>
+int status;
+SDL_mutex *mutex;
+
+mutex = SDL_CreateMutex();
+if (!mutex) {
+  SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create mutex\n");
+  return;
+}
+
+status = SDL_LockMutex(mutex);
+
+if (status == 0) {
+  SDL_Log("Locked mutex\n");
+  SDL_UnlockMutex(mutex);
+} else {
+  SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't lock mutex\n");
+}
+
+SDL_DestroyMutex(mutex);
+</syntaxhighlight>
+<!-- # End Mutex Example -->
 
 ----
 [[CategoryAPI]], [[CategoryMutex]]


### PR DESCRIPTION
Edit of: https://wiki.libsdl.org/SDL_LockMutex

This includes the fixes requested in #195.

The example consists in:
- Locking with `SDL_LockMutex`.
- Describing how to handle the return value.
