### PR TITLE
SDL_SemWait: Added code example.

### DIFF
--- a/SDL_SemWait.mediawiki
+++ b/SDL_SemWait.mediawiki
@@ -36,7 +36,41 @@ This function is available since SDL 2.0.0.
 
 == Code Examples ==
 
-<<Include(SDL_CreateSemaphore, , , from="## Begin Semaphore Example", to="## End Semaphore Example")>>
+<!-- # Begin Semaphore Example -->
+<syntaxhighlight lang='c'>
+#define NB_WAITER 10
+
+SDL_sem *sem;
+
+// Increments the semaphore every 2s
+int poster_thread() {
+  for (int i = 0; i < NB_WAITER; i++) {
+    SDL_SemPost(sem);
+    SDL_Delay(2 * 1000);
+  }
+  return 0;
+}
+
+int waiter_thread() {
+  int status;
+
+  status = SDL_SemWait(sem);
+  
+  if (status == 0) {
+    SDL_Log("Semaphore was decremented.\n");
+  } else {
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "An error has occured while waiting: %s\n", SDL_GetError());
+  }
+  return 0;
+}
+
+int main() {
+  sem = SDL_CreateSemaphore(0);
+  create_and_wait_threads(); // 1 poster, 10 waiters
+  SDL_DestroySemaphore(sem);
+}
+</syntaxhighlight>
+<!-- # End Semaphore Example -->
 
 == Related Functions ==
 


### PR DESCRIPTION
Edit of: https://wiki.libsdl.org/SDL_SemWait

This includes the fixes requested in #196.

This examples consists in:
- A single thread calling post on the semaphore every 2 seconds.
- Ten threads, each calling `SDL_SemWait` on the semaphore.
- Describing how to handle the return value of `SDL_SemWait`.