### PR TITLE
Threading: Replaced printf in code examples.

### DIFF
--- a/SDL_CreateMutex.mediawiki
+++ b/SDL_CreateMutex.mediawiki
@@ -30,12 +30,12 @@ This function is available since SDL 2.0.0.
 == Code Examples ==
 
 <!-- # Begin Mutex Example -->
-<syntaxhighlight lang='c++'>
+<syntaxhighlight lang='c'>
 SDL_mutex *mutex;
 
 mutex = SDL_CreateMutex();
 if (!mutex) {
-  fprintf(stderr, "Couldn't create mutex\n");
+  SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create mutex\n");
   return;
 }
 
@@ -43,7 +43,7 @@ if (SDL_LockMutex(mutex) == 0) {
   /* Do stuff while mutex is locked */
   SDL_UnlockMutex(mutex);
 } else {
-  fprintf(stderr, "Couldn't lock mutex\n");
+  SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't lock mutex\n");
 }
 
 SDL_DestroyMutex(mutex);

--- a/SDL_CreateThread.mediawiki
+++ b/SDL_CreateThread.mediawiki
@@ -42,8 +42,7 @@ This function is available since SDL 2.0.0.
 
 == Code Examples ==
 
-<syntaxhighlight lang='c++'>
-#include <stdio.h>
+<syntaxhighlight lang='c'>
 #include "SDL.h"
 
 /* Very simple thread - counts 0 to 9 delaying 50ms between increments */
@@ -52,7 +51,7 @@ static int TestThread(void *ptr)
     int cnt;
 
     for (cnt = 0; cnt < 10; ++cnt) {
-        printf("Thread counter: %d\n", cnt);
+        SDL_Log("Thread counter: %d\n", cnt);
         SDL_Delay(50);
     }
 
@@ -64,22 +63,22 @@ int main(int argc, char *argv[])
     SDL_Thread *thread;
     int         threadReturnValue;
 
-    printf("Simple SDL_CreateThread test:\n");
+    SDL_Log("Simple SDL_CreateThread test:\n");
 
     /* Simply create a thread */
     thread = SDL_CreateThread(TestThread, "TestThread", (void *)NULL);
 
     if (NULL == thread) {
-        printf("SDL_CreateThread failed: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_CreateThread failed: %s\n", SDL_GetError());
     } else {
         SDL_WaitThread(thread, &threadReturnValue);
-        printf("Thread returned value: %d\n", threadReturnValue);
+        SDL_Log("Thread returned value: %d\n", threadReturnValue);
     }
 
     return 0;
 }
 </syntaxhighlight>
-<syntaxhighlight lang='c++'>
+<syntaxhighlight lang='c'>
 Output:
 Simple SDL_CreateThread test:
 Thread counter: 0

--- a/SDL_GetThreadID.mediawiki
+++ b/SDL_GetThreadID.mediawiki
@@ -32,8 +32,7 @@ This function is available since SDL 2.0.0.
 
 == Code Examples ==
 
-<syntaxhighlight lang='c++'>
-#include <stdio.h>
+<syntaxhighlight lang='c'>
 #include "SDL.h"
 
 // Very simple thread - counts 0 to 9 delaying 50ms between increments
@@ -42,7 +41,7 @@ int TestThread(void *ptr)
     int cnt;
 
     for (cnt = 0; cnt < 10; ++cnt) {
-        printf("\nThread counter: %d", cnt);
+        SDL_Log("\nThread counter: %d", cnt);
         SDL_Delay(50);
     }
 
@@ -55,13 +54,13 @@ int main(int argc, char *argv[])
     SDL_threadID threadID;
     int          threadReturnValue;
 
-    printf("\nSimple SDL_CreateThread test:");
+    SDL_Log("\nSimple SDL_CreateThread test:");
 
     /* Simply create a thread */
     thread = SDL_CreateThread(TestThread, "TestThread", (void *)NULL);
 
     if (NULL == thread) {
-        printf("\nSDL_CreateThread failed: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "\nSDL_CreateThread failed: %s\n", SDL_GetError());
         exit(-1);
     }
 
@@ -70,7 +69,7 @@ int main(int argc, char *argv[])
 
     /* Wait for the thread to complete and get the return code */
     SDL_WaitThread(thread, &threadReturnValue);
-    printf("\nThread returned value: %d", threadReturnValue);
+    SDL_Log("\nThread returned value: %d", threadReturnValue);
 
     return 0;
 }

--- a/SDL_TryLockMutex.mediawiki
+++ b/SDL_TryLockMutex.mediawiki
@@ -39,25 +39,25 @@ This function is available since SDL 2.0.0.
 
 == Code Examples ==
 
-<syntaxhighlight lang='c++'>
+<syntaxhighlight lang='c'>
 int status;
 SDL_mutex *mutex;
 
 mutex = SDL_CreateMutex();
 if (!mutex) {
-  fprintf(stderr, "Couldn't create mutex\n");
+  SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create mutex\n");
   return;
 }
 
 status = SDL_TryLockMutex(mutex);
 
 if (status == 0) {
-  printf("Locked mutex\n");
+  SDL_Log("Locked mutex\n");
   SDL_UnlockMutex(mutex);
 } else if (status == SDL_MUTEX_TIMEDOUT) {
   /* Mutex not available for locking right now */
 } else {
-  fprintf(stderr, "Couldn't lock mutex\n");
+  SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't lock mutex\n");
 }
 
 SDL_DestroyMutex(mutex);

--- a/SDL_WaitThread.mediawiki
+++ b/SDL_WaitThread.mediawiki
@@ -45,10 +45,8 @@ This function is available since SDL 2.0.0.
 
 == Code Examples ==
 
-<syntaxhighlight lang='c++'>
-#include <stdio.h>
-#include "SDL_thread.h"
-#include "SDL_timer.h"
+<syntaxhighlight lang='c'>
+#include "SDL.h"
 
 // Very simple thread - counts 0 to 9 delaying 50ms between increments
 static int TestThread(void *ptr)
@@ -56,7 +54,7 @@ static int TestThread(void *ptr)
     int cnt;
 
     for (cnt = 0; cnt < 10; ++cnt) {
-        printf("\nThread counter: %d", cnt);
+        SDL_Log("Thread counter: %d\n", cnt);
         SDL_Delay(50);
     }
 
@@ -69,19 +67,19 @@ int main(int argc, char *argv[])
     SDL_Thread *thread;
     int         threadReturnValue;
 
-    printf("\nSimple SDL_CreateThread test:");
+    SDL_Log("Simple SDL_CreateThread test:");
 
     // Simply create a thread
     thread = SDL_CreateThread(TestThread, "TestThread", (void *)NULL);
 
     if (NULL == thread) {
-        printf("\nSDL_CreateThread failed: %s\n", SDL_GetError());
+        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "SDL_CreateThread failed: %s\n", SDL_GetError());
     } else {
         // Wait for the thread to complete. The thread functions return code will
         //       be placed in the "threadReturnValue" variable when it completes.
         //
         SDL_WaitThread(thread, &threadReturnValue);
-        printf("\nThread returned value: %d", threadReturnValue);
+        SDL_Log("Thread returned value: %d\n", threadReturnValue);
     }
 
     return 0;


### PR DESCRIPTION
Edits of:
- https://wiki.libsdl.org/SDL_TryLockMutex
- https://wiki.libsdl.org/SDL_CreateMutex
- https://wiki.libsdl.org/SDL_WaitThread
- https://wiki.libsdl.org/SDL_GetThreadID
- https://wiki.libsdl.org/SDL_CreateThread

This PR brings a few minor corrections to threading code examples:
- all occurrences of `(f)printf` have been replaced by `SDL_Log(Error)`.
- removed `sdtio.h` if it was no longer necessary to the example.
- corrected syntax highlighting to be `c` instead of `c++`.