### PR TITLE
SDL_version/VERSION: Added code example.

### DIFF
--- a/SDL_VERSION.mediawiki
+++ b/SDL_VERSION.mediawiki
@@ -21,7 +21,18 @@ Fills the selected struct with:
 : (x)->patch = SDL_PATCHLEVEL
 
 == Code Examples ==
-<<Include(SDL_GetVersion, , , from="== Code Examples ==", to="== Remarks")>>
+
+<syntaxhighlight lang='c'>
+SDL_version compiled;
+SDL_version linked;
+
+SDL_VERSION(&compiled);
+SDL_GetVersion(&linked);
+SDL_Log("We compiled against SDL version %u.%u.%u ...\n",
+       compiled.major, compiled.minor, compiled.patch);
+SDL_Log("But we are linking against SDL version %u.%u.%u.\n",
+       linked.major, linked.minor, linked.patch);
+</syntaxhighlight>
 
 == Remarks ==
 This macro fills in an [[SDL_version]] structure with the version of the library you compiled against. This is determined by what header the compiler uses. Note that if you dynamically linked the library, you might have a slightly newer or older version at runtime. That version can be determined with [[SDL_GetVersion]]() which, unlike [[SDL_VERSION]](), is not a macro.

--- a/SDL_version.mediawiki
+++ b/SDL_version.mediawiki
@@ -19,7 +19,18 @@ A structure that contains information about the version of SDL in use.
 |}
 
 == Code Examples ==
-<<Include(SDL_GetVersion, , , from="== Code Examples ==", to="== Remarks")>>
+
+<syntaxhighlight lang='c'>
+SDL_version compiled;
+SDL_version linked;
+
+SDL_VERSION(&compiled);
+SDL_GetVersion(&linked);
+SDL_Log("We compiled against SDL version %u.%u.%u ...\n",
+       compiled.major, compiled.minor, compiled.patch);
+SDL_Log("But we are linking against SDL version %u.%u.%u.\n",
+       linked.major, linked.minor, linked.patch);
+</syntaxhighlight>
 
 == Remarks ==
 Represents the library's version as three levels:


### PR DESCRIPTION
Edits of:
- https://wiki.libsdl.org/SDL_VERSION
- https://wiki.libsdl.org/SDL_version

This PR replaces the `Include(SDL_GetVersion...)` statements in both pages with a copy of the updated example proposed in #200. 