### PR TITLE
CategoryTimer: Added link to GetTicks64 on Timer page.

### DIFF
--- a/CategoryTimer.mediawiki
+++ b/CategoryTimer.mediawiki
@@ -24,6 +24,7 @@ This category contains functions for handling the SDL time management routines.
 * [[SDL_GetPerformanceCounter]]
 * [[SDL_GetPerformanceFrequency]]
 * [[SDL_GetTicks]]
+* [[SDL_GetTicks64]]
 * [[SDL_RemoveTimer]]
 * [[SDL_TICKS_PASSED]]
 <!-- END CATEGORY LIST -->


### PR DESCRIPTION
This edit adds a link to [SDL_GetTicks64](https://wiki.libsdl.org/SDL_GetTicks64) on the [Timer Category](https://wiki.libsdl.org/CategoryTimer) page.