### PR TITLE
SDL_GetTicks64: Add timer category.

### DIFF
--- a/SDL_GetTicks64.mediawiki
+++ b/SDL_GetTicks64.mediawiki
@@ -34,6 +34,4 @@ while (SDL_GetTicks64() < timeout) {
 This function is available since SDL 2.0.18.
 
 ----
-[[CategoryAPI]]
-
-
+[[CategoryAPI]], [[CategoryTimer]]


### PR DESCRIPTION
This PR aims to bring the same changes as #207.

The bot reverted the changes presumably because the `SDL_GetTicks64` page lacked `CategoryTimer` at the bottom.

Apologies for the redundancy with the previous PR.