### PR TITLE
SDL2&SDL3: Add missing categories to struct and enum pages

### DIFF
--- a/SDL2/SDL_DisplayEvent.md
+++ b/SDL2/SDL_DisplayEvent.md
@@ -35,3 +35,6 @@ while (SDL_PollEvent(&ev) != 0) {
 ## Remarks
 [SDL_DisplayEvent](https://wiki.libsdl.org/SDL_DisplayEvent) is a member of the [SDL_Event](https://wiki.libsdl.org/SDL_Event) union and is used when an event of type SDL_DISPLAYEVENT is reported.  You would access it through the event's <code>display</code> field.
 
+----
+[CategoryStruct](CategoryStruct), [CategoryEvents](CategoryEvents)
+

--- a/SDL2/SDL_DisplayEventID.mediawiki
+++ b/SDL2/SDL_DisplayEventID.mediawiki
@@ -18,4 +18,5 @@ Event subtype for display events
 |}
 
 ----
-[[CategoryEnum]], [[CategoryEvents]]
+[[CategoryEnum]], [[CategoryVideo]], [[CategoryEvents]]
+

--- a/SDL2/SDL_DisplayOrientation.md
+++ b/SDL2/SDL_DisplayOrientation.md
@@ -15,3 +15,7 @@ Enumeration of Display Orientations
 ## Related Functions
 
 [SDL_GetDisplayOrientation](https://wiki.libsdl.org/SDL_GetDisplayOrientation)
+
+----
+[CategoryEnum](CategoryEnum), [CategoryVideo](CategoryVideo)
+

--- a/SDL2/SDL_FlashOperation.md
+++ b/SDL2/SDL_FlashOperation.md
@@ -13,3 +13,7 @@ Enumeration of Window Flash Operations
 ## Related Functions
 
 [SDL_FlashWindow](https://wiki.libsdl.org/SDL_FlashWindow)
+
+----
+[CategoryEnum](CategoryEnum), [CategoryVideo](CategoryVideo)
+

--- a/SDL2/SDL_GameControllerBindType.mediawiki
+++ b/SDL2/SDL_GameControllerBindType.mediawiki
@@ -36,4 +36,5 @@ An enumeration of the different kinds of SDL_Joystick controls a [[SDL_GameContr
 :[[SDL_GameControllerGetBindForButton]]
 
 ----
-[[CategoryEnum]], [[CategoryHeader]], [[CategoryDraft]]
+[[CategoryEnum]], [[CategoryGameController]], [[CategoryDraft]]
+

--- a/SDL2/SDL_SysWMmsg.mediawiki
+++ b/SDL2/SDL_SysWMmsg.mediawiki
@@ -95,4 +95,5 @@ There are currently no Cocoa or UIKit window events.
 :[[SDL_version]]
 
 ----
-[[CategoryStruct]], [[CategorySWM]]
+[[CategoryStruct]], [[CategoryEvents]], [[CategorySWM]]
+

--- a/SDL2/SDL_SystemCursor.mediawiki
+++ b/SDL2/SDL_SystemCursor.mediawiki
@@ -41,3 +41,7 @@ Hover over the descriptions to see the cursor.
 |SDL_SYSTEM_CURSOR_HAND
 |<span style="cursor:pointer;">Hand</span>
 |}
+
+----
+[[CategoryEnum]], [[CategoryMouse]]
+

--- a/SDL3/SDL_DisplayEvent.md
+++ b/SDL3/SDL_DisplayEvent.md
@@ -35,3 +35,6 @@ while (SDL_PollEvent(&ev) != 0) {
 ## Remarks
 [SDL_DisplayEvent](https://wiki.libsdl.org/SDL_DisplayEvent) is a member of the [SDL_Event](https://wiki.libsdl.org/SDL_Event) union and is used when an event of type SDL_DISPLAYEVENT is reported.  You would access it through the event's <code>display</code> field.
 
+----
+[CategoryStruct](CategoryStruct), [CategoryEvents](CategoryEvents)
+

--- a/SDL3/SDL_FlashOperation.md
+++ b/SDL3/SDL_FlashOperation.md
@@ -13,3 +13,7 @@ Enumeration of Window Flash Operations
 ## Related Functions
 
 [SDL_FlashWindow](https://wiki.libsdl.org/SDL_FlashWindow)
+
+----
+[CategoryEnum](CategoryEnum), [CategoryVideo](CategoryVideo)
+

--- a/SDL3/SDL_SysWMmsg.mediawiki
+++ b/SDL3/SDL_SysWMmsg.mediawiki
@@ -95,4 +95,5 @@ There are currently no Cocoa or UIKit window events.
 :[[SDL_version]]
 
 ----
-[[CategoryStruct]], [[CategorySWM]]
+[[CategoryStruct]], [[CategoryEvents]], [[CategorySWM]]
+

--- a/SDL3/SDL_SystemCursor.mediawiki
+++ b/SDL3/SDL_SystemCursor.mediawiki
@@ -41,3 +41,7 @@ Hover over the descriptions to see the cursor.
 |SDL_SYSTEM_CURSOR_HAND
 |<span style="cursor:pointer;">Hand</span>
 |}
+
+----
+[[CategoryEnum]], [[CategoryMouse]]
+


### PR DESCRIPTION
Add struct and enum categories and category for the SDL header it's defined in to the struct and enum pages that are missing them.