### PR TITLE
SDL2/CategoryMessageBox: fix typo

### DIFF
--- a/SDL2/CategoryMessageBox.mediawiki
+++ b/SDL2/CategoryMessageBox.mediawiki
@@ -20,7 +20,7 @@ The functions in this category are used configure and display system message box
 == Functions ==
 <<FullSearchCached(category:CategoryMessagebox -CategoryEnum -CategoryStruct -title:SGFunctions)>>
 <!-- BEGIN CATEGORY LIST -->
-* [[SDL_ShowMesssageBox]]
+* [[SDL_ShowMessageBox]]
 * [[SDL_ShowSimpleMessageBox]]
 <!-- END CATEGORY LIST -->
 ----


### PR DESCRIPTION
Fixes typo causing broken link