### PR TITLE
Fix Windows path separators.

### DIFF
--- a/SDL2/SDL_GetBasePath.md
+++ b/SDL2/SDL_GetBasePath.md
@@ -44,7 +44,7 @@ Supported values for the
 directory of the application as it is uncommon to store resources outside
 the executable. As such it is not a writable directory.
 
-The returned path is guaranteed to end with a path separator ('\' on
+The returned path is guaranteed to end with a path separator ('\\' on
 Windows, '/' on most other platforms).
 
 The pointer returned is owned by the caller. Please call

--- a/SDL2/SDL_GetPrefPath.md
+++ b/SDL2/SDL_GetPrefPath.md
@@ -60,7 +60,7 @@ follow these rules:
 - ...only use letters, numbers, and spaces. Avoid punctuation like "Game
   Name 2: Bad Guy's Revenge!" ... "Game Name 2" is sufficient.
 
-The returned path is guaranteed to end with a path separator ('\' on
+The returned path is guaranteed to end with a path separator ('\\' on
 Windows, '/' on most other platforms).
 
 The pointer returned is owned by the caller. Please call

--- a/SDL3/SDL_GetBasePath.md
+++ b/SDL3/SDL_GetBasePath.md
@@ -44,7 +44,7 @@ Supported values for the
 directory of the application as it is uncommon to store resources outside
 the executable. As such it is not a writable directory.
 
-The returned path is guaranteed to end with a path separator ('\' on
+The returned path is guaranteed to end with a path separator ('\\' on
 Windows, '/' on most other platforms).
 
 The pointer returned is owned by the caller. Please call

--- a/SDL3/SDL_GetPrefPath.md
+++ b/SDL3/SDL_GetPrefPath.md
@@ -60,7 +60,7 @@ follow these rules:
 - ...only use letters, numbers, and spaces. Avoid punctuation like "Game
   Name 2: Bad Guy's Revenge!" ... "Game Name 2" is sufficient.
 
-The returned path is guaranteed to end with a path separator ('\' on
+The returned path is guaranteed to end with a path separator ('\\' on
 Windows, '/' on most other platforms).
 
 The pointer returned is owned by the caller. Please call


### PR DESCRIPTION
The backslashes were escaping the following ' character instead of being displayed.