### PR TITLE
fix a misinformation on Mix_HaltChannel.md

### DIFF
--- a/SDL2_mixer/Mix_HaltChannel.md
+++ b/SDL2_mixer/Mix_HaltChannel.md
@@ -22,7 +22,7 @@ int Mix_HaltChannel(int channel);
 
 ## Return Value
 
-Returns 0 on success, or -1 on error.
+Returns zero, regardless of whether on success or not.
 
 ## Remarks
 

--- a/SDL3_mixer/Mix_HaltChannel.md
+++ b/SDL3_mixer/Mix_HaltChannel.md
@@ -22,7 +22,7 @@ int Mix_HaltChannel(int channel);
 
 ## Return Value
 
-Returns 0 on success, or -1 on error.
+Returns zero, regardless of whether on success or not.
 
 ## Remarks
 


### PR DESCRIPTION
Sorry for my bad english.

I have noticed on
[https://wiki.libsdl.org/SDL2_mixer/Mix_HaltChannel](https://wiki.libsdl.org/SDL2_mixer/Mix_HaltChannel) and
[https://wiki.libsdl.org/SDL3_mixer/Mix_HaltChannel](https://wiki.libsdl.org/SDL3_mixer/Mix_HaltChannel)
say "Returns 0 on success, or -1 on error.", but in
[SDL2/src/mixer.c](https://github.com/libsdl-org/SDL_mixer/blob/SDL2/src/mixer.c#L1257) and 
[SDL3/src/mixer.c](https://github.com/libsdl-org/SDL_mixer/blob/main/src/mixer.c#L1228)
are only return 0 without any error code.