### PR TITLE
Update SDL3/SDL_DialogFile* examples

### DIFF
--- a/SDL3/SDL_DialogFileCallback.md
+++ b/SDL3/SDL_DialogFileCallback.md
@@ -55,8 +55,7 @@ static const SDL_DialogFileFilter filters[] = {
     { "PNG images",  "png" },
     { "JPEG images", "jpg;jpeg" },
     { "All images",  "png;jpg;jpeg" },
-    { "All files",   "*" },
-    { NULL, NULL }
+    { "All files",   "*" }
 };
 
 static void SDLCALL callback(void* userdata, const char* const* filelist, int filter)
@@ -75,14 +74,13 @@ static void SDLCALL callback(void* userdata, const char* const* filelist, int fi
         filelist++;
     }
 
-    if (filter == -1) {
+    if (filter < 0) {
         SDL_Log("The current platform does not support fetching "
-                "the selected filter.");
+                "the selected filter, or the user did not select"
+                " any filter.");
     } else if (filter < SDL_arraysize(filters)) {
         SDL_Log("The filter selected by the user is '%s' (%s).",
                 filters[filter].pattern, filters[filter].name);
-    } else {
-        SDL_Log("The user did not select any filter.");
     }
 }
 ```

--- a/SDL3/SDL_DialogFileFilter.md
+++ b/SDL3/SDL_DialogFileFilter.md
@@ -33,15 +33,14 @@ This struct is available since SDL 3.0.0.
 
 ## Code Examples
 
-This structure is most often used as a **NULL-terminated** array:
+This structure is most often used as an array:
 
 ```c
 const SDL_DialogFileFilter filters[] = {
     { "PNG images",  "png" },
     { "JPEG images", "jpg;jpeg" },
     { "All images",  "png;jpg;jpeg" },
-    { "All files",   "*" },
-    { NULL, NULL }
+    { "All files",   "*" }
 };
 ```
 


### PR DESCRIPTION
Some examples were outdated; I've updated them to follow the latest API changes. Specifically, the array of filters is no longer `NULL`-terminated, and the filter argument of the callback no longer distinguishes "No filter selected" and "Fetching selected filter is unsupported".