### PR TITLE
Fix SDL_Vulkan_GetInstanceExtensions example

### DIFF
--- a/SDL3/SDL_Vulkan_GetInstanceExtensions.md
+++ b/SDL3/SDL_Vulkan_GetInstanceExtensions.md
@@ -57,7 +57,7 @@ const char * const *instance_extensions = SDL_Vulkan_GetInstanceExtensions(&coun
 
 if (instance_extensions == NULL) { handle_error(); }
 
-int count_extensions = count_instance_extensions;
+int count_extensions = count_instance_extensions + 1;
 const char **extensions = SDL_malloc(count_extensions * sizeof(const char *));
 extensions[0] = VK_EXT_DEBUG_REPORT_EXTENSION_NAME;
 SDL_memcpy(&extensions[1], instance_extensions, count_instance_extensions * sizeof(const char*)); 


### PR DESCRIPTION
Fix a bug from the C++ to C conversion in cb047371215fed1ccfb68721218522cfda68ce85