### PR TITLE
Add [CategoryPen] to pen related events

### DIFF
--- a/SDL3/SDL_EVENT_PEN_AXIS.md
+++ b/SDL3/SDL_EVENT_PEN_AXIS.md
@@ -4,5 +4,5 @@
 Please refer to [SDL_EventType](SDL_EventType) for details.
 
 ----
-[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators)
+[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators), [CategoryPen](CategoryPen)
 

--- a/SDL3/SDL_EVENT_PEN_BUTTON_DOWN.md
+++ b/SDL3/SDL_EVENT_PEN_BUTTON_DOWN.md
@@ -4,5 +4,5 @@
 Please refer to [SDL_EventType](SDL_EventType) for details.
 
 ----
-[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators)
+[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators), [CategoryPen](CategoryPen)
 

--- a/SDL3/SDL_EVENT_PEN_BUTTON_UP.md
+++ b/SDL3/SDL_EVENT_PEN_BUTTON_UP.md
@@ -4,5 +4,5 @@
 Please refer to [SDL_EventType](SDL_EventType) for details.
 
 ----
-[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators)
+[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators), [CategoryPen](CategoryPen)
 

--- a/SDL3/SDL_EVENT_PEN_DOWN.md
+++ b/SDL3/SDL_EVENT_PEN_DOWN.md
@@ -4,5 +4,5 @@
 Please refer to [SDL_EventType](SDL_EventType) for details.
 
 ----
-[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators)
+[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators), [CategoryPen](CategoryPen)
 

--- a/SDL3/SDL_EVENT_PEN_MOTION.md
+++ b/SDL3/SDL_EVENT_PEN_MOTION.md
@@ -4,5 +4,5 @@
 Please refer to [SDL_EventType](SDL_EventType) for details.
 
 ----
-[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators)
+[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators), [CategoryPen](CategoryPen)
 

--- a/SDL3/SDL_EVENT_PEN_PROXIMITY_IN.md
+++ b/SDL3/SDL_EVENT_PEN_PROXIMITY_IN.md
@@ -4,5 +4,5 @@
 Please refer to [SDL_EventType](SDL_EventType) for details.
 
 ----
-[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators)
+[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators), [CategoryPen](CategoryPen)
 

--- a/SDL3/SDL_EVENT_PEN_PROXIMITY_OUT.md
+++ b/SDL3/SDL_EVENT_PEN_PROXIMITY_OUT.md
@@ -4,5 +4,5 @@
 Please refer to [SDL_EventType](SDL_EventType) for details.
 
 ----
-[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators)
+[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators), [CategoryPen](CategoryPen)
 

--- a/SDL3/SDL_EVENT_PEN_UP.md
+++ b/SDL3/SDL_EVENT_PEN_UP.md
@@ -4,5 +4,5 @@
 Please refer to [SDL_EventType](SDL_EventType) for details.
 
 ----
-[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators)
+[CategoryAPI](CategoryAPI), [CategoryAPIEnumerators](CategoryAPIEnumerators), [CategoryPen](CategoryPen)
 

--- a/SDL3/SDL_PenAxisEvent.md
+++ b/SDL3/SDL_PenAxisEvent.md
@@ -35,5 +35,5 @@ tablet.
 This struct is available since SDL 3.1.3.
 
 ----
-[CategoryAPI](CategoryAPI), [CategoryAPIStruct](CategoryAPIStruct), [CategoryEvents](CategoryEvents)
+[CategoryAPI](CategoryAPI), [CategoryAPIStruct](CategoryAPIStruct), [CategoryEvents](CategoryEvents), [CategoryPen](CategoryPen)
 

--- a/SDL3/SDL_PenButtonEvent.md
+++ b/SDL3/SDL_PenButtonEvent.md
@@ -36,5 +36,5 @@ itself pressing down to draw triggers a
 This struct is available since SDL 3.1.3.
 
 ----
-[CategoryAPI](CategoryAPI), [CategoryAPIStruct](CategoryAPIStruct), [CategoryEvents](CategoryEvents)
+[CategoryAPI](CategoryAPI), [CategoryAPIStruct](CategoryAPIStruct), [CategoryEvents](CategoryEvents), [CategoryPen](CategoryPen)
 

--- a/SDL3/SDL_PenMotionEvent.md
+++ b/SDL3/SDL_PenMotionEvent.md
@@ -37,5 +37,5 @@ motion.
 This struct is available since SDL 3.1.3.
 
 ----
-[CategoryAPI](CategoryAPI), [CategoryAPIStruct](CategoryAPIStruct), [CategoryEvents](CategoryEvents)
+[CategoryAPI](CategoryAPI), [CategoryAPIStruct](CategoryAPIStruct), [CategoryEvents](CategoryEvents), [CategoryPen](CategoryPen)
 

--- a/SDL3/SDL_PenProximityEvent.md
+++ b/SDL3/SDL_PenProximityEvent.md
@@ -39,5 +39,5 @@ and [SDL_EVENT_PEN_UP](SDL_EVENT_PEN_UP).
 This struct is available since SDL 3.1.3.
 
 ----
-[CategoryAPI](CategoryAPI), [CategoryAPIStruct](CategoryAPIStruct), [CategoryEvents](CategoryEvents)
+[CategoryAPI](CategoryAPI), [CategoryAPIStruct](CategoryAPIStruct), [CategoryEvents](CategoryEvents), [CategoryPen](CategoryPen)
 

--- a/SDL3/SDL_PenTouchEvent.md
+++ b/SDL3/SDL_PenTouchEvent.md
@@ -35,5 +35,5 @@ off from one.
 This struct is available since SDL 3.1.3.
 
 ----
-[CategoryAPI](CategoryAPI), [CategoryAPIStruct](CategoryAPIStruct), [CategoryEvents](CategoryEvents)
+[CategoryAPI](CategoryAPI), [CategoryAPIStruct](CategoryAPIStruct), [CategoryEvents](CategoryEvents), [CategoryPen](CategoryPen)
 


### PR DESCRIPTION
Adds https://wiki.libsdl.org/SDL3/CategoryPen to pen related structs and enum members defined in `SDL_events.h`