### PR TITLE
Add code examples for SDL_CreateTray

### DIFF
--- a/SDL3/SDL_CreateTray.md
+++ b/SDL3/SDL_CreateTray.md
@@ -35,6 +35,61 @@ Using tray icons require the video subsystem.
 
 This function should only be called on the main thread.
 
+## Code Examples
+
+A simple program that creates a system tray with a single button that quits the
+program:
+
+```c
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+
+void callback_quit(void *userdata, SDL_TrayEntry *invoker)
+{
+    SDL_Event e;
+    e.type = SDL_EVENT_QUIT;
+    SDL_PushEvent(&e);
+}
+
+int main(int argc, char *argv[])
+{
+    SDL_Tray *tray;
+    SDL_TrayMenu *menu;
+    SDL_TrayEntry *entry;
+    SDL_Event e;
+
+    SDL_Init(SDL_INIT_VIDEO);
+
+    // Create the entry in the system tray. A regular app will want to provide
+    // an SDL_Surface instead of NULL.
+    tray = SDL_CreateTray(NULL, "My tray");
+
+    // Create a context menu for the tray.
+    menu = SDL_CreateTrayMenu(tray);
+
+    // Create a button in the comtext menu.
+    entry = SDL_InsertTrayEntryAt(menu, -1, "Quit", SDL_TRAYENTRY_BUTTON);
+
+    // Set the callback for the button
+    SDL_SetTrayEntryCallback(entry, callback_quit, NULL);
+
+    // Run the main loop...
+    while (SDL_WaitEvent(&e)) {
+        if (e.type == SDL_EVENT_QUIT) {
+            break;
+        }
+    }
+
+    // No need to destroy anything other than the tray itself - the rest is
+    // destroyed automatically.
+    SDL_DestroyTray(tray);
+
+    SDL_Quit();
+
+    return 0;
+}
+```
+
 ## Version
 
 This function is available since SDL 3.2.0.


### PR DESCRIPTION
This adds a very basic example program to give a quick start for developers wanting to use trays.

Closes https://github.com/libsdl-org/SDL/issues/12214

Some things to check before merging:
- I haven't put all the error checking that I've done for `testtray` because I wanted to go for maximum simplicity; should I add some error checking?
- I've only added the example in `SDL_CreateTray` because I felt that was the most natural entry point to trays; should I add a note in the documentation of other functions to redirect people to SDL_CreateTray for some example code?
- Should I add the "See also" links of the functions I used in the SDL_CreateTray page?