### PR TITLE
Added links to the Examples and Demos onto the FrontPage.md

### DIFF
--- a/SDL3/FrontPage.md
+++ b/SDL3/FrontPage.md
@@ -45,6 +45,8 @@ This is the SDL wiki. SDL's main website is [libsdl.org](https://libsdl.org/).
 
 - [Tutorials](Tutorials)
 - [Articles](Articles)
+- [Examples](https://examples.libsdl.org/SDL3/) small programs that each demonstrate one feature of the library
+- [Demos](https://examples.libsdl.org/SDL3/demo/) simple-but-complete games and apps
 - [SDL 2.0 Migration Guide](README-migration)
 - [Frequently Asked Questions](FAQs)
 - [READMEs](READMEs) covering more advanced topics


### PR DESCRIPTION
These were things I was looking for a couple of times, and couldn't easily find in the place I expected it, which was this list. They are linked from the Tutorials page, which is also a good place for them to be linked. I feel having them linked in both places is the best. That doubles the chances of people seeing them!

I got the description text from the Tutorials page.