### PR TITLE
SDL3/SDL_GamepadButton: Added additional first party controller examples to cover Paddles/Misc

### DIFF
--- a/SDL3/SDL_GamepadButton.md
+++ b/SDL3/SDL_GamepadButton.md
@@ -28,8 +28,8 @@ typedef enum SDL_GamepadButton
     SDL_GAMEPAD_BUTTON_DPAD_LEFT,
     SDL_GAMEPAD_BUTTON_DPAD_RIGHT,
     SDL_GAMEPAD_BUTTON_MISC1,           /**< Additional button (e.g. Xbox Series X share button, PS5 microphone button, Nintendo Switch Pro capture button, Amazon Luna microphone button, Google Stadia capture button) */
-    SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1,   /**< Upper or primary paddle, under your right hand (e.g. Xbox Elite paddle P1, PS5 DualSense Edge RB button, Nintendo Switch Joy-Con (L) SR, Steam Deck L4 button) */
-    SDL_GAMEPAD_BUTTON_LEFT_PADDLE1,    /**< Upper or primary paddle, under your left hand (e.g. Xbox Elite paddle P3, PS5 DualSense Edge LB button, Nintendo Switch Joy-Con (L) SL, Steam Deck L5 button) */
+    SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1,   /**< Upper or primary paddle, under your right hand (e.g. Xbox Elite paddle P1, PS5 DualSense Edge RB button, Nintendo Switch Joy-Con (L) SR button, Steam Deck L4 button) */
+    SDL_GAMEPAD_BUTTON_LEFT_PADDLE1,    /**< Upper or primary paddle, under your left hand (e.g. Xbox Elite paddle P3, PS5 DualSense Edge LB button, Nintendo Switch Joy-Con (L) SL button, Steam Deck L5 button) */
     SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2,   /**< Lower or secondary paddle, under your right hand (e.g. Xbox Elite paddle P2, Nintendo Switch Joy-Con (R) SR button, Steam Deck R4 button) */
     SDL_GAMEPAD_BUTTON_LEFT_PADDLE2,    /**< Lower or secondary paddle, under your left hand (e.g. Xbox Elite paddle P4, Nintendo Switch Joy-Con (R) SR button, Steam Deck R5 button) */
     SDL_GAMEPAD_BUTTON_TOUCHPAD,        /**< PS4/PS5 touchpad button */


### PR DESCRIPTION
In a attempt to make it easier for first party developers who don't have a supported controller but still wanna ensure that the glyph placement is correct: additional examples are added for Paddles and Misc buttons

this will include

- Dualsense Edge
- Nintendo Switch Joy-Cons
- Nintendo GameCube


```
    SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1,   /**< Upper or primary paddle, under your right hand (e.g. Xbox Elite paddle P1, PS5 DualSense Edge RB button, Nintendo Switch Joy-Con (L) SR, Steam Deck L4) */
    SDL_GAMEPAD_BUTTON_LEFT_PADDLE1,    /**< Upper or primary paddle, under your left hand (e.g. Xbox Elite paddle P3, PS5 DualSense Edge LB button, Nintendo Switch Joy-Con (L) SL, Steam Deck L5) */
    SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2,   /**< Lower or secondary paddle, under your right hand (e.g. Xbox Elite paddle P2, Nintendo Switch Joy-Con R SR, Steam Deck R4) */
    SDL_GAMEPAD_BUTTON_LEFT_PADDLE2,    /**<  Lower or secondary paddle, under your left hand (e.g. Xbox Elite paddle P4, Nintendo Switch Joy-Con R SR, Steam Deck R5 */
    SDL_GAMEPAD_BUTTON_TOUCHPAD,        /**< PS4/PS5 touchpad button */
    SDL_GAMEPAD_BUTTON_MISC2,           /**< Additional button */
    SDL_GAMEPAD_BUTTON_MISC3,           /**< Additional button (e.g. Nintendo GameCube right trigger click) */
    SDL_GAMEPAD_BUTTON_MISC4,           /**< Additional button (e.g. Nintendo GameCube left trigger click) */
    SDL_GAMEPAD_BUTTON_MISC5,           /**< Additional button */
    SDL_GAMEPAD_BUTTON_MISC6,           /**< Additional button */
```