### PR TITLE
Fix link to SDL2/SDL_DestroyTexture from IMG_LoadTexture

### DIFF
--- a/SDL2_image/IMG_LoadTexture.md
+++ b/SDL2_image/IMG_LoadTexture.md
@@ -56,7 +56,7 @@ This function is available since SDL_image 2.0.0.
 
 - [IMG_LoadTextureTyped_RW](IMG_LoadTextureTyped_RW)
 - [IMG_LoadTexture_RW](IMG_LoadTexture_RW)
-- [SDL_DestroyTexture](SDL_DestroyTexture)
+- [SDL_DestroyTexture](../SDL2/SDL_DestroyTexture)
 
 ----
 [CategoryAPI](CategoryAPI), [CategoryAPIFunction](CategoryAPIFunction)


### PR DESCRIPTION
The link points to https://wiki.libsdl.org/SDL2_image/SDL_DestroyTexture but that page does not exist, it should be https://wiki.libsdl.org/SDL2/SDL_DestroyTexture instead.