### PR TITLE
Add SDL_shadercross to CI checkouts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,12 @@ jobs:
         repository: libsdl-org/SDL_rtf
         ref: SDL2
         path: external/SDL2_rtf
+    - name: Checkout SDL3_shadercross
+      uses: actions/checkout@v4
+      with:
+        repository: libsdl-org/SDL_shadercross
+        ref: main
+        path: external/SDL3_shadercross
     - name: Setup dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
Checks out SDL_shadercross alongside the other satellite libraries, so example code in SDL3_shadercross wiki pages compiles against the real headers.

Ref: libsdl-org/SDL#15989
