### PR TITLE
Fix SDL3_rtf checkout path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
       with:
         repository: libsdl-org/SDL_rtf
         ref: main
-        path: external/SDL2_rtf
+        path: external/SDL3_rtf
     - name: Checkout SDL2_rtf
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
The "Checkout SDL3_rtf" step checked out to `external/SDL2_rtf`, which the next step ("Checkout SDL2_rtf") then overwrote, so the SDL3_rtf source tree was never actually available. Corrected to `external/SDL3_rtf`, matching the `SDL3_x → external/SDL3_x` pattern used by every other library.
